### PR TITLE
Added 'wp_mail_ses_sent_email' filter on the SES response

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -9,7 +9,27 @@ if (!function_exists('wp_mail')) {
             $headers,
             $attachments
         );
-
-        return !empty($id);
+		
+		$mail_data = array(
+			'ses_message_id'	=> $id,
+			'to' 				=> $to,
+			'subject'			=> $subject,
+            'message'			=> $message,
+            'headers'			=> $headers,
+            'attachments'		=> $attachments
+		);
+		
+		$wp_mail_standard_response = !empty($id);
+		
+		/**
+		 * Filter the SES response on email sent.
+		 *
+		 * Use this filter to intercept (and maybe change) the SES message ID before the plugin set it to just 0 (on failure) or 1 (on email sent ok) .
+		 *
+		 * @param bool $wp_mail_standard_response The response in the format that wp_mail() expect it. I.e. 0 or 1.
+		 *
+		 * @param array mail_data An Array with all the data of the email sent and the SES message id returned. The array's key are: 'ses_message_id', 'to', 'subject', 'message', 'headers', 'attachments'
+		 */
+		return apply_filters( 'wp_mail_ses_sent_email', $wp_mail_standard_response, $mail_data);
     }
 }


### PR DESCRIPTION
Use this filter to intercept (and maybe change) the SES message ID
before the plugin set it to just 0 (on failure) or 1 (on email sent ok).

For example I use it to store the message id of the sent email so that I can then match it with the bounce or failure notification

Note that the filter is completly transparent: if you don't aler it, the default response (that is in the format that wp_mail() send is mantained)

I'll be glad to provide any other information if you need it, but it's really a simple simple hack
.
